### PR TITLE
[libqmfclient] Modify .provider/.service to be less generic

### DIFF
--- a/qmf/src/libraries/qmfclient/qmailstore_p.cpp
+++ b/qmf/src/libraries/qmfclient/qmailstore_p.cpp
@@ -6044,7 +6044,7 @@ QMailStorePrivate::AttemptResult QMailStorePrivate::attemptAddAccount(QMailAccou
     }
 
     // Create new account in Accounts subsystem
-    QSharedPointer<Accounts::Account> ssoAccount(manager->createAccount("GenericProvider"));
+    QSharedPointer<Accounts::Account> ssoAccount(manager->createAccount("email"));
     if (!ssoAccount) {
         SSOHandleError(manager->lastError());
         qMailLog(Messaging) << "Failed to create account";

--- a/qmf/src/libraries/qmfclient/qmfclient.pro
+++ b/qmf/src/libraries/qmfclient/qmfclient.pro
@@ -187,12 +187,12 @@ packagesExist(accounts-qt) | packagesExist(accounts-qt5) {
                ssoauthplugin.cpp
 
     # THIS NEEDS TO BE CHECKED
-    # Install generic SSO provider description
-    sso_providers.files = share/GenericProvider.provider
+    # Install email SSO provider description
+    sso_providers.files = share/email.provider
     sso_providers.path  = $$QMF_INSTALL_ROOT/share/accounts/providers
 
-    # Install generic SSO service description
-    sso_services.files = share/GenericEmail.service
+    # Install email SSO service description
+    sso_services.files = share/email.service
     sso_services.path  = $$QMF_INSTALL_ROOT/share/accounts/services
 
     INSTALLS += sso_providers sso_services

--- a/qmf/src/libraries/qmfclient/share/email.provider
+++ b/qmf/src/libraries/qmfclient/share/email.provider
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<provider id="GenericProvider">
-  <name>Other mail account</name>
-  <icon>generic_provider</icon>
+<provider id="email">
+  <name>Email account</name>
 
   <template>
     <group name="auth">

--- a/qmf/src/libraries/qmfclient/share/email.service
+++ b/qmf/src/libraries/qmfclient/share/email.service
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<service id="GenericEmail">
+<service id="email">
   <type>e-mail</type>
-  <name>Other mail account</name>
-  <icon>generic_email</icon>
-  <provider>GenericProvider</provider>
+  <name>Email Service</name>
+  <provider>email</provider>
 
   <!-- default settings (account settings have precedence over these) -->
   <template>


### PR DESCRIPTION
Previously, the .provider and .service files used very generic names
and icon values.  Also, the default icon value was specified via a
relative path, which might not exist.  This commit renames both the
provider and service to be less generic, and ensures that the default
icons used come from the system theme (if such a provider exists).
