### PR TITLE
[qmf] fix packaging dependencies

### DIFF
--- a/qmf/src/tools/accountscheck/accountscheck.pro
+++ b/qmf/src/tools/accountscheck/accountscheck.pro
@@ -8,6 +8,7 @@ target.path += /usr/bin
 CONFIG += link_pkgconfig
 PKGCONFIG += accounts-qt5
 LIBS += -lqmfclient5
+LIBS += -L../../libraries/qmfclient/build
 
 SOURCES += accountscheck.cpp
 


### PR DESCRIPTION
Fixed pkgconfig dependency on qmfclient5, use LIBS instead
