### PR TITLE
[qmf] Don't call signon-ui from background process.

### DIFF
--- a/qmf/src/libraries/qmfclient/ssoauthplugin.h
+++ b/qmf/src/libraries/qmfclient/ssoauthplugin.h
@@ -59,8 +59,8 @@ public:
     virtual QString key() const = 0;
     virtual QList<QByteArray> authentication(const SignOn::SessionData &sessionData,
                                          const QString &serviceType, const QString &userName, int serviceAuthentication) const = 0;
-    virtual SignOn::SessionData sessionData(const QString &accountProvider, QVariantMap authParameters,
-                                            bool setUiPolicy) const = 0;
+    virtual void credentialsNeedUpdate(int accountId) = 0;
+    virtual SignOn::SessionData sessionData(const QString &accountProvider, QVariantMap authParameters) const = 0;
     virtual SSOAuthService *createService() = 0;
 };
 

--- a/qmf/src/libraries/qmfclient/ssosessionmanager.h
+++ b/qmf/src/libraries/qmfclient/ssosessionmanager.h
@@ -49,6 +49,7 @@
 #include <qglobal.h>
 
 // Accounts
+#include <Accounts/Account>
 #include <SignOn/Identity>
 #include <SignOn/SessionData>
 
@@ -64,8 +65,9 @@ public:
     void cancel();
     bool createSsoIdentity(const QMailAccountId &id,
                            const QString &serviceType, int serviceAuthentication);
+    void credentialsNeedUpdate();
     void deleteSsoIdentity();
-    void recreateSsoIdentity(bool setUiPolicy = true);
+    void recreateSsoIdentity();
     void removeSsoIdentity();
     bool waitForSso();
 
@@ -82,6 +84,7 @@ private:
     QString serviceCredentialsId(const QString &serviceType) const;
 
     int _serviceAuthentication;
+    int _accountId;
     bool _waitForSso;
     QByteArray _ssoLogin;
     QString _authMethod;

--- a/qmf/src/plugins/messageservices/imap/imapclient.h
+++ b/qmf/src/plugins/messageservices/imap/imapclient.h
@@ -168,6 +168,7 @@ private:
 
 #ifdef USE_ACCOUNTS_QT
     void ssoProcessLogin();
+    void ssoCredentialsNeedUpdate();
 #endif
     void deactivateConnection();
     void retrieveOperationCompleted();
@@ -208,7 +209,6 @@ private:
     bool _loginFailed;
     bool _sendLogin;
     bool _recreateIdentity;
-    bool _accountUpdated;
     QByteArray _ssoLogin;
 #endif
 };

--- a/qmf/src/plugins/messageservices/pop/popclient.h
+++ b/qmf/src/plugins/messageservices/pop/popclient.h
@@ -126,6 +126,7 @@ protected slots:
 
 private:
 #ifdef USE_ACCOUNTS_QT
+    void ssoCredentialsNeedUpdate();
     void ssoProcessLogin();
 #endif
     void deactivateConnection();
@@ -211,7 +212,6 @@ private:
     SSOSessionManager* ssoSessionManager;
     bool loginFailed;
     bool sendLogin;
-    bool accountUpdated;
     QList<QByteArray> ssoLogin;
 #endif
 };

--- a/qmf/src/plugins/messageservices/smtp/smtpclient.h
+++ b/qmf/src/plugins/messageservices/smtp/smtpclient.h
@@ -78,6 +78,7 @@ public:
     QMailAccountId account() const;
 
 #ifdef USE_ACCOUNTS_QT
+    void ssoCredentialsNeedUpdate();
     void removeSsoIdentity(const QMailAccountId &accountId);
 #endif
 
@@ -174,7 +175,6 @@ private:
     SSOSessionManager* ssoSessionManager;
     bool loginFailed;
     bool sendLogin;
-    bool accountUpdated;
     QList<QByteArray> ssoLogin;
 #endif
 };

--- a/qmf/src/plugins/ssoauth/password/passwordplugin.cpp
+++ b/qmf/src/plugins/ssoauth/password/passwordplugin.cpp
@@ -160,15 +160,20 @@ QList<QByteArray> SSOPasswordPlugin::authentication(const SignOn::SessionData &s
     }
 }
 
-SignOn::SessionData SSOPasswordPlugin::sessionData(const QString &accountProvider,  QVariantMap authParameters,
-                                                   bool setUiPolicy) const
+void SSOPasswordPlugin::credentialsNeedUpdate(int accountId)
+{
+    // For the password method we don't do anything, messageserver
+    // already informs the clients about login failed.
+    Q_UNUSED(accountId);
+}
+
+SignOn::SessionData SSOPasswordPlugin::sessionData(const QString &accountProvider,  QVariantMap authParameters) const
 {
     Q_UNUSED(accountProvider);
     Q_UNUSED(authParameters);
 
     SignOn::SessionData data;
-    if (setUiPolicy)
-        data.setUiPolicy(SignOn::RequestPasswordPolicy);
+    data.setUiPolicy(SignOn::NoUserInteractionPolicy);
     return data;
 }
 

--- a/qmf/src/plugins/ssoauth/password/passwordplugin.h
+++ b/qmf/src/plugins/ssoauth/password/passwordplugin.h
@@ -61,8 +61,8 @@ public:
     virtual QString key() const;
     virtual QList<QByteArray> authentication(const SignOn::SessionData &sessionData,
                                          const QString &serviceType, const QString &userName, int serviceAuthentication) const;
-    virtual SignOn::SessionData sessionData(const QString &accountProvider, QVariantMap authParameters,
-                                            bool setUiPolicy) const;
+    virtual void credentialsNeedUpdate(int accountId);
+    virtual SignOn::SessionData sessionData(const QString &accountProvider, QVariantMap authParameters) const;
     virtual SSOAuthService* createService();
 
 private:


### PR DESCRIPTION
Set credentials need update when SSO autenthication fails.
