### PR TITLE
[qmf] Update email.provider icon

### DIFF
--- a/qmf/src/libraries/qmfclient/share/email.provider
+++ b/qmf/src/libraries/qmfclient/share/email.provider
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <provider id="email">
   <name>Email</name>
-  <icon>image://theme/icon-m-service-generic-email</icon>
+  <icon>image://theme/graphic-service-generic-mail</icon>
 
   <template>
     <group name="auth">

--- a/qmf/src/libraries/qmfclient/share/email.service
+++ b/qmf/src/libraries/qmfclient/share/email.service
@@ -2,7 +2,7 @@
 <service id="email">
   <type>e-mail</type>
   <name>Email</name>
-  <icon>image://theme/icon-m-service-generic-email</icon>
+  <icon>image://theme/graphic-service-generic-mail</icon>
   <provider>email</provider>
 
   <!-- default settings (account settings have precedence over these) -->
@@ -13,7 +13,7 @@
     <setting name="signature"></setting>
     <setting name="emailaddress"></setting>
     <setting name="enabled" type="b">false</setting>
-    <setting name="iconPath" type="s">image://theme/icon-m-service-generic-email</setting>
+    <setting name="iconPath" type="s">image://theme/graphic-service-generic-mail</setting>
     <group name="auth">
             <setting name="method">password</setting>
             <setting name="mechanism">password</setting>


### PR DESCRIPTION
Higher quality icon image path is now used by default
