### PR TITLE
[qmf] Make SMTP AUTH PLAIN more robust.

### DIFF
--- a/qmf/src/plugins/messageservices/smtp/smtpauthenticator.cpp
+++ b/qmf/src/plugins/messageservices/smtp/smtpauthenticator.cpp
@@ -63,10 +63,10 @@ QByteArray SmtpAuthenticator::getAuthentication(const QMailAccountConfiguration:
     SmtpConfiguration smtpCfg(svcCfg);
     if (smtpCfg.smtpAuthentication() != SmtpConfiguration::Auth_NONE) {
         QMailAccountId id(smtpCfg.id());
-        QByteArray username(smtpCfg.smtpUsername().toLatin1());
+        QByteArray username(smtpCfg.smtpUsername().toUtf8());
         QByteArray pass;
         if (ssoLogin.isEmpty()) {
-            pass = smtpCfg.smtpPassword().toLatin1();
+            pass = smtpCfg.smtpPassword().toUtf8();
             qMailLog(SMTP) << Q_FUNC_INFO << "SSO identity is not found for account id: "<< id
                            << ", using password from accounts configuration";
         } else {
@@ -80,7 +80,7 @@ QByteArray SmtpAuthenticator::getAuthentication(const QMailAccountConfiguration:
             result = QByteArray("LOGIN");
             gResponses[id] = (QList<QByteArray>() << username << pass);
         } else if (smtpCfg.smtpAuthentication() == SmtpConfiguration::Auth_PLAIN) {
-            result = QByteArray("PLAIN");
+            result = QByteArray("PLAIN ") + QByteArray(username + '\0' + username + '\0' + pass).toBase64();
             gResponses[id] = (QList<QByteArray>() << QByteArray(username + '\0' + username + '\0' + pass));
         }
     }
@@ -123,8 +123,8 @@ QByteArray SmtpAuthenticator::getAuthentication(const QMailAccountConfiguration:
     SmtpConfiguration smtpCfg(svcCfg);
     if (smtpCfg.smtpAuthentication() != SmtpConfiguration::Auth_NONE) {
         QMailAccountId id(smtpCfg.id());
-        QByteArray username(smtpCfg.smtpUsername().toLatin1());
-        QByteArray password(smtpCfg.smtpPassword().toLatin1());
+        QByteArray username(smtpCfg.smtpUsername().toUtf8());
+        QByteArray password(smtpCfg.smtpPassword().toUtf8());
 
         if (smtpCfg.smtpAuthentication() == SmtpConfiguration::Auth_LOGIN) {
             result = QByteArray("LOGIN");

--- a/qmf/src/plugins/ssoauth/password/passwordplugin.cpp
+++ b/qmf/src/plugins/ssoauth/password/passwordplugin.cpp
@@ -121,15 +121,15 @@ QList<QByteArray> SSOPasswordPlugin::getSMTPAuthentication(const QString &passwo
                                                     const QString &username, int serviceAuthentication) const
 {
     QList<QByteArray> result;
-    QByteArray user(username.toLatin1());
-    QByteArray pass(password.toLatin1());
+    QByteArray user(username.toUtf8());
+    QByteArray pass(password.toUtf8());
 
     if (serviceAuthentication == QMail::LoginMechanism) {
         result.append(QByteArray("AUTH LOGIN"));
         result.append(QByteArray(user));
         result.append(QByteArray(pass));
     } else if (serviceAuthentication == QMail::PlainMechanism) {
-        result.append(QByteArray("AUTH PLAIN"));
+        result.append(QByteArray("AUTH PLAIN ") + QByteArray(user + '\0' + user + '\0' + pass).toBase64());
         result.append(QByteArray(user + '\0' + user + '\0' + pass));
     } else if (serviceAuthentication == QMail::CramMd5Mechanism) {
         result.append(QByteArray(pass));


### PR DESCRIPTION
SMTP authentication using AUTH PLAIN supports two ways to send authentication information to the server,
seems that some servers don't support anymore auth in two steps:

c: AUTH PLAIN
S: 334
C: <UserName and password encoded in base64>
S: 235 2.7.0 Authentication successful

Auth in one step introduced by this commit, reduces communication with the server

c: AUTH PLAIN <UserName and password encoded in base64>
S: 235 2.7.0 Authentication successful
