### PR TITLE
Fix encodedWord regular expression(RFC 2047) to match quoted email addresses properly.

### DIFF
--- a/qmf/tests/tst_qmailmessage/tst_qmailmessage.cpp
+++ b/qmf/tests/tst_qmailmessage/tst_qmailmessage.cpp
@@ -802,6 +802,57 @@ CRLF
                       << QString("This is a message just to say hello.\nSo, ""Hello"".") // plain_text
                       << int( 0 ); // message_part_count
 
+    QTest::newRow("encoded_words_with_quotes") << QByteArray(
+"From:\"=?UTF-8?Q?J=6fhn=20D=6fe?=\" <jdoe@machine.example>" CRLF
+"To:\"=?UTF-8?Q?Mary_S=6dith?=\" <mary@example.net>" CRLF
+"Subject:=?\"UTF-8\"?B?U2F5aW5nIEhlbGxv?= =?ISO-8859-1?Q?_Encoded_?= =?UTF-8?Q?=41=42=43?=" CRLF
+"Date: Fri, 21 Nov 1997 09:55:06 -0600" CRLF
+"Message-ID: <1234@local.machine.example>" CRLF
+CRLF
+"This is a message just to say hello." CRLF
+"So, ""Hello"".") // rfc_text
+                      << QString("John Doe <jdoe@machine.example>") // from
+                      << QString("John Doe") // from_name
+                      << QString("jdoe@machine.example") // from_email
+                      << QStringList("Mary Smith <mary@example.net>") // to
+                      << QStringList() // cc
+                      << QStringList() // bcc
+                      << QString("Saying Hello Encoded ABC") // subject
+                      << QString() // reply_to
+                      << QString() // in_reply_to
+                      << QString("<1234@local.machine.example>") // message_id
+                      << QDateTime(QDate(1997,11,21), QTime(15,55,6), Qt::UTC).toLocalTime() // datetime
+                      << QString( "Fri, 21 Nov 1997 09:55:06 -0600" ) // date_str
+                      << int(QMailMessage::Email) // type
+                      << QString("This is a message just to say hello.\nSo, ""Hello"".") // plain_text
+                      << int( 0 ); // message_part_count
+
+    QTest::newRow("encoded_words_without_spaces_in_the_subject") << QByteArray(
+"From:\"=?UTF-8?Q?J=6fhn=20D=6fe?=\" <jdoe@machine.example>" CRLF
+"To:\"=?UTF-8?Q?Mary_S=6dith?=\" <mary@example.net>" CRLF
+"Subject:=?\"UTF-8\"?B?U2F5aW5nIEhlbGxv?==?ISO-8859-1?Q?_Encoded_?==?UTF-8?Q?=41=42=43?=" CRLF
+"Date: Fri, 21 Nov 1997 09:55:06 -0600" CRLF
+"Message-ID: <1234@local.machine.example>" CRLF
+CRLF
+"This is a message just to say hello." CRLF
+"So, ""Hello"".") // rfc_text
+                      << QString("John Doe <jdoe@machine.example>") // from
+                      << QString("John Doe") // from_name
+                      << QString("jdoe@machine.example") // from_email
+                      << QStringList("Mary Smith <mary@example.net>") // to
+                      << QStringList() // cc
+                      << QStringList() // bcc
+                      << QString("Saying Hello Encoded ABC") // subject
+                      << QString() // reply_to
+                      << QString() // in_reply_to
+                      << QString("<1234@local.machine.example>") // message_id
+                      << QDateTime(QDate(1997,11,21), QTime(15,55,6), Qt::UTC).toLocalTime() // datetime
+                      << QString( "Fri, 21 Nov 1997 09:55:06 -0600" ) // date_str
+                      << int(QMailMessage::Email) // type
+                      << QString("This is a message just to say hello.\nSo, ""Hello"".") // plain_text
+                      << int( 0 ); // message_part_count
+
+
     QTest::newRow("long_header") << QByteArray(
 "From: John Doe <jdoe@machine.example>" CRLF
 "To: Mary Smith <mary@example.net>" CRLF

--- a/qmf/tests/tst_qmailmessageheader/tst_qmailmessageheader.cpp
+++ b/qmf/tests/tst_qmailmessageheader/tst_qmailmessageheader.cpp
@@ -790,12 +790,10 @@ void tst_QMailMessageHeaderField::encodeWord_data()
         << QByteArray("ISO-8859-1")
         << QByteArray("=?ISO-8859-1?Q?mary=40example=2Enet?=");
 
-    /* Qt Extended seems to be configured without iso-8859-[^1]
     QTest::newRow("ISO-8859-2 encoding")
         << QString("hello")
         << QByteArray("ISO-8859-2")
         << QByteArray("=?ISO-8859-2?Q?hello?=");
-    */
 
     QString latin1Address(QString::fromLatin1("Joh\361 D\366e <jdoe@machine.test>"));
 
@@ -815,6 +813,11 @@ void tst_QMailMessageHeaderField::encodeWord_data()
         << latin1Address
         << QByteArray("ISO-8859-1")
         << QByteArray("=?ISO-8859-1?Q?=22Joh=F1_D=F6e=22_=3Cjdoe=40machine=2Etest=3E?=");
+
+    QTest::newRow("ISO-8859-1 with accents")
+        << QString::fromLatin1("(título águia João)")
+        << QByteArray("ISO-8859-1")
+        << QByteArray("=?ISO-8859-1?Q?=28t=C3=ADtulo_=C3=A1guia_Jo=C3=A3o=29?=");
 
     const QChar chars[] = { 0x0636, 0x0669, 0x06a5, 0x06b4 };
     QString unicodeAddress(chars, 4);
@@ -840,6 +843,16 @@ void tst_QMailMessageHeaderField::encodeWord_data()
         << unicodeAddress
         << QByteArray()
         << QByteArray("=?UTF-8?B?2LbZqdql2rQgPGFkZHJlc3NAZXhhbXBsZT7Yttmp2qXatCA8YWRkcmVzc0Bl?= =?UTF-8?B?eGFtcGxlPg==?=");
+
+    QTest::newRow("UTF-8 accents")
+        << QString::fromLatin1("[Test] (título águia João)")
+        << QByteArray("UTF-8")
+        << QByteArray("=?UTF-8?B?W1Rlc3RdICh0w4PCrXR1bG8gw4PCoWd1aWEgSm/Dg8Kjbyk=?=");
+
+    QTest::newRow("UTF8 empty")
+        << QString::fromLatin1("")
+        << QByteArray("UTF-8")
+        << QByteArray("=?UTF-8?B?" "?=");
 }
 
 void tst_QMailMessageHeaderField::encodeWord()


### PR DESCRIPTION
E.g of quoted email address: "From: \"=?ISO-8859-1?Q?=22Joh=F1_D=F6e=22?=\" jdoe@example.net"

Change-Id: I640fb127d640585099289558c6080cd1b698c331
Signed-off-by: Valerio Valerio valerio.valerio@jollamobile.com

Cherry-picked from upstream commit: 78c9582b11e9ea7f9e99bf0b89ee8db6cb276b12.
