### PR TITLE
[qmf] Force refresh of SSO tokens when token returned is the same as last one that failed.

### DIFF
--- a/qmf/src/libraries/qmfclient/ssosessionmanager.h
+++ b/qmf/src/libraries/qmfclient/ssosessionmanager.h
@@ -79,14 +79,21 @@ protected slots:
     void ssoResponse(const SignOn::SessionData &sessionData);
     void ssoSessionError(const SignOn::Error &code);
 
+private slots:
+    void reAuthenticate();
+
 private:
     bool authPluginAvailable(const QString &method) const;
     QString serviceUsername(const QString &serviceType) const;
     QString serviceCredentialsId(const QString &serviceType) const;
+    void forceTokenRefresh();
+    void sessionResponse(const SignOn::SessionData &sessionData);
 
     int _serviceAuthentication;
     int _accountId;
     bool _waitForSso;
+    bool _recreatingSession;
+    bool _reAuthenticate;
     QByteArray _ssoLogin;
     QString _authMethod;
     QString _authMechanism;
@@ -98,6 +105,9 @@ private:
     SSOAuthService *_authService;
     SignOn::Identity *_identity;
     SignOn::AuthSession *_session;
+    SignOn::SessionData _sessionData;
+    QVariantMap _oldToken;
+    QVariantMap _refreshSessionData;
 };
 
 #endif // SSOSESSIONMANAGER_H


### PR DESCRIPTION
SSO returns many times a already expired token, if the token returned is the same that we just tried to use without success, we force a refresh by invalidating current token.
