### PR TITLE
[qmf] Always restart messageserver5 service regardless of exit status

### DIFF
--- a/qmf/src/tools/systemd/messageserver5.service
+++ b/qmf/src/tools/systemd/messageserver5.service
@@ -7,7 +7,7 @@ After=booster-generic.service
 Type=simple
 ExecStartPre=/usr/bin/qmf-accountscheck
 ExecStart=/usr/bin/invoker -o --type=generic --global-syms /usr/bin/messageserver5
-Restart=on-failure
+Restart=always
 RestartSec=1
 
 [Install]


### PR DESCRIPTION
on-failure does not restart the service if it gives a 'successful' exit code, which messageserver5 will do in response to SIGINT, SIGTERM, or a command from clients.
