### PR TITLE
[qmf] Add enablers for credentials checking.

### DIFF
--- a/qmf/src/libraries/qmfclient/ssosessionmanager.cpp
+++ b/qmf/src/libraries/qmfclient/ssosessionmanager.cpp
@@ -81,6 +81,7 @@ SSOSessionManager::SSOSessionManager(QObject *parent)
       _waitForSso(false),
       _recreatingSession(false),
       _reAuthenticate(false),
+      _credentialsCheck(false),
       _identity(0),
       _session(0)
 {
@@ -171,6 +172,8 @@ bool SSOSessionManager::createSsoIdentity(const QMailAccountId &id, const QStrin
         return false;
     }
 
+    _credentialsCheck = account->valueAsBool("credentialsCheck");
+
     // Some plugins stores an identity per service.
     // If there is no specific credentials for the specific service than we should check regular credentialsId.
     // This allows to store different credentials for incoming and outgoing servers for example.
@@ -200,6 +203,14 @@ bool SSOSessionManager::createSsoIdentity(const QMailAccountId &id, const QStrin
         _session = 0;
         return false;
     }
+}
+
+/*!
+  Returns true if credentials checking is being performed for this account, otherwise returns false.
+*/
+bool SSOSessionManager::checkingCredentials() const
+{
+    return _credentialsCheck;
 }
 
 /*!

--- a/qmf/src/libraries/qmfclient/ssosessionmanager.h
+++ b/qmf/src/libraries/qmfclient/ssosessionmanager.h
@@ -65,6 +65,7 @@ public:
     void cancel();
     bool createSsoIdentity(const QMailAccountId &id,
                            const QString &serviceType, int serviceAuthentication);
+    bool checkingCredentials() const;
     void credentialsNeedUpdate();
     void deleteSsoIdentity();
     void recreateSsoIdentity();
@@ -94,6 +95,7 @@ private:
     bool _waitForSso;
     bool _recreatingSession;
     bool _reAuthenticate;
+    bool _credentialsCheck;
     QByteArray _ssoLogin;
     QString _authMethod;
     QString _authMechanism;

--- a/qmf/src/plugins/messageservices/imap/imapclient.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapclient.cpp
@@ -793,7 +793,10 @@ void ImapClient::checkCommandResponse(ImapCommand command, OperationStatus statu
                 // We try only once to recreate the sso identity and relogin,
                 // in order to allow user interaction if defined by the sso
                 // plugin.
-                if (!_loginFailed && _recreateIdentity) {
+                if (_ssoSessionManager && _ssoSessionManager->checkingCredentials()) {
+                    operationFailed(QMailServiceAction::Status::ErrLoginFailed, _protocol.lastError());
+                    return;
+                } else if (!_loginFailed && _recreateIdentity) {
                     _loginFailed = true;
                     _sendLogin = true;
                     ssoProcessLogin();

--- a/qmf/src/plugins/messageservices/pop/popclient.cpp
+++ b/qmf/src/plugins/messageservices/pop/popclient.cpp
@@ -534,12 +534,16 @@ void PopClient::processResponse(const QString &response)
         if (response[0] != '+') {
             // Authentication failed
 #ifdef USE_ACCOUNTS_QT
-            if (ssoSessionManager && !loginFailed) {
-                loginFailed = true;
-                ssoProcessLogin();
-            } else {
-                ssoCredentialsNeedUpdate();
+            if (ssoSessionManager && ssoSessionManager->checkingCredentials()) {
                 operationFailed(QMailServiceAction::Status::ErrLoginFailed, "");
+            } else {
+                if (ssoSessionManager && !loginFailed) {
+                    loginFailed = true;
+                    ssoProcessLogin();
+                } else {
+                    ssoCredentialsNeedUpdate();
+                    operationFailed(QMailServiceAction::Status::ErrLoginFailed, "");
+                }
             }
 #else
             operationFailed(QMailServiceAction::Status::ErrLoginFailed, "");

--- a/qmf/src/plugins/messageservices/smtp/smtpservice.cpp
+++ b/qmf/src/plugins/messageservices/smtp/smtpservice.cpp
@@ -125,7 +125,10 @@ SmtpService::SmtpService(const QMailAccountId &accountId)
 
     _client.setAccount(accountId);
 
+// Don't try to autoconnect on account creation for SSO services
+#ifndef USE_ACCOUNTS_QT
     fetchCapabilities();
+#endif
 }
 
 void SmtpService::fetchCapabilities()


### PR DESCRIPTION
Don't try to re-create SSO sessions when accounts are in checking mode.
Don't try to autoconnect to SMTP server during account setup.
