### PR TITLE
[qmf] Fix race condition when fetching large amouth of data over IMAP4.

### DIFF
--- a/qmf/src/plugins/messageservices/imap/imapconfiguration.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapconfiguration.cpp
@@ -210,7 +210,6 @@ void ImapConfiguration::setSearchLimit(int limit)
 
 bool ImapConfiguration::acceptUntrustedCertificates() const
 {
-    qDebug() << Q_FUNC_INFO << value("acceptUntrustedCertificates", "0");
     return (value("acceptUntrustedCertificates", "0").toInt() != 0);
 }
 

--- a/qmf/src/plugins/messageservices/imap/imapprotocol.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapprotocol.cpp
@@ -2865,7 +2865,6 @@ ImapProtocol::ImapProtocol()
       _authenticated(false),
       _receivedCapabilities(false)
 {
-    connect(&_incomingDataTimer, SIGNAL(timeout()), this, SLOT(incomingData()));
     connect(&_fsm->listState, SIGNAL(mailboxListed(QString, QString)),
             this, SIGNAL(mailboxListed(QString, QString)));
     connect(&_fsm->genUrlAuthState, SIGNAL(urlAuthorized(QString)),
@@ -3325,12 +3324,9 @@ void ImapProtocol::incomingData()
 
         readLines++;
         if (readLines >= MAX_LINES) {
-            _incomingDataTimer.start(0);
-            return;
+            incomingData();
         }
     }
-
-    _incomingDataTimer.stop();
 }
 
 void ImapProtocol::continuation(ImapCommand command, const QString &recv)

--- a/qmf/src/plugins/messageservices/imap/imapprotocol.h
+++ b/qmf/src/plugins/messageservices/imap/imapprotocol.h
@@ -311,7 +311,6 @@ private:
 
     QString _unprocessedInput;
 
-    QTimer _incomingDataTimer;
     bool _flatHierarchy;
     QChar _delimiter;
     bool _authenticated;

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -1,6 +1,6 @@
 Name: qmf-qt5
 Summary:    Qt Messaging Framework (QMF) Qt5
-Version:    4.0.4+git13
+Version:    4.0.4+git15
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1 with exception or GPLv3


### PR DESCRIPTION
QTimer stops the processing of incoming data due to race condition.
