### PR TITLE
[qmf] Prevents IMAP4 incoming data read from stopping when handling large requests.

### DIFF
--- a/qmf/src/libraries/qmfmessageserver/qmailtransport.cpp
+++ b/qmf/src/libraries/qmfmessageserver/qmailtransport.cpp
@@ -383,11 +383,27 @@ bool QMailTransport::canReadLine() const
 }
 
 /*!
+    Returns true if the transport is readable and there are bytes available to read; otherwise returns false.
+*/
+bool QMailTransport::bytesAvailable() const
+{
+    return mSocket->isReadable() && mSocket->bytesAvailable();
+}
+
+/*!
     Reads a line from the device, but no more than \a maxSize characters, and returns the result as a QByteArray.
 */
 QByteArray QMailTransport::readLine(qint64 maxSize)
 {
     return mSocket->readLine(maxSize);
+}
+
+/*!
+    Reads all the data available in the device, and returns the result as a QByteArray.
+*/
+QByteArray QMailTransport::readAll()
+{
+    return mSocket->readAll();
 }
 
 /*! \internal */

--- a/qmf/src/libraries/qmfmessageserver/qmailtransport.h
+++ b/qmf/src/libraries/qmfmessageserver/qmailtransport.h
@@ -102,7 +102,9 @@ public:
 
     // Read line-oriented data from the transport (must have an open connection)
     bool canReadLine() const;
+    bool bytesAvailable() const;
     QByteArray readLine(qint64 maxSize = 0);
+    QByteArray readAll();
 
     // Assists with counting bytes written to the device
     void mark();

--- a/qmf/src/plugins/messageservices/imap/imapprotocol.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapprotocol.cpp
@@ -3319,6 +3319,11 @@ QString ImapProtocol::sendCommandLiteral(const QString &cmd, uint length)
 
 void ImapProtocol::incomingData()
 {
+    if (!_lineBuffer.isEmpty() && _transport->imapCanReadLine()) {
+        processResponse(QString::fromLatin1(_lineBuffer + _transport->imapReadLine()));
+        _lineBuffer.clear();
+    }
+
     int readLines = 0;
     while (_transport->imapCanReadLine()) {
         processResponse(QString::fromLatin1(_transport->imapReadLine()));
@@ -3328,6 +3333,11 @@ void ImapProtocol::incomingData()
             _incomingDataTimer.start(0);
             return;
         }
+    }
+
+    if (_transport->bytesAvailable()) {
+        // If there is an incomplete line, read it from the socket buffer to ensure we get readyRead signal next time
+        _lineBuffer.append(_transport->readAll());
     }
 
     _incomingDataTimer.stop();

--- a/qmf/src/plugins/messageservices/imap/imapprotocol.h
+++ b/qmf/src/plugins/messageservices/imap/imapprotocol.h
@@ -318,6 +318,7 @@ private:
     bool _receivedCapabilities;
 
     static const int MAX_LINES = 30;
+    QByteArray _lineBuffer;
 };
 
 #endif

--- a/qmf/src/plugins/messageservices/imap/imaptransport.cpp
+++ b/qmf/src/plugins/messageservices/imap/imaptransport.cpp
@@ -126,7 +126,9 @@ public:
 
     bool consume(QIODevice *in);
     bool canReadLine() const;
+    bool bytesAvailable() const;
     QByteArray readLine();
+    QByteArray readAll();
 
 private:
     int _chunkSize;
@@ -183,6 +185,11 @@ bool Rfc1951Decompressor::canReadLine() const
     return _output.contains('\n');
 }
 
+bool Rfc1951Decompressor::bytesAvailable() const
+{
+    return !_output.isEmpty();
+}
+
 QByteArray Rfc1951Decompressor::readLine()
 {
     int eolPos = _output.indexOf('\n');
@@ -192,6 +199,13 @@ QByteArray Rfc1951Decompressor::readLine()
     
     QByteArray result = _output.left(eolPos + 1);
     _output = _output.mid(eolPos + 1);
+    return result;
+}
+
+QByteArray Rfc1951Decompressor::readAll()
+{
+    QByteArray result =  _output;
+    _output.clear();
     return result;
 }
 #else
@@ -212,7 +226,9 @@ public:
 
     bool consume(QIODevice *) { return true; }
     bool canReadLine() const { return true; }
+    bool bytesAvailable() const { return true; }
     QByteArray readLine() { return QByteArray(); }
+    QByteArray readAll() { return QByteArray(); }
 };
 #endif
 
@@ -242,12 +258,30 @@ bool ImapTransport::imapCanReadLine()
     }
 }
 
+bool ImapTransport::imapBytesAvailable()
+{
+    if(!compress()) {
+        return bytesAvailable();
+    } else {
+        return _decompressor->bytesAvailable();
+    }
+}
+
 QByteArray ImapTransport::imapReadLine()
 {
     if (!compress()) {
         return readLine();
     } else {
         return _decompressor->readLine();
+    }
+}
+
+QByteArray ImapTransport::imapReadAll()
+{
+    if (!compress()) {
+        return readAll();
+    } else {
+        return _decompressor->readAll();
     }
 }
 

--- a/qmf/src/plugins/messageservices/imap/imaptransport.h
+++ b/qmf/src/plugins/messageservices/imap/imaptransport.h
@@ -63,7 +63,9 @@ public:
 
     // Read line-oriented data from the transport (must have an open connection)
     bool imapCanReadLine();
+    bool imapBytesAvailable();
     QByteArray imapReadLine();
+    QByteArray imapReadAll();
 
     // Write data to the transport (must have an open connection)
     bool imapWrite(QByteArray *in);

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -1,6 +1,6 @@
 Name: qmf-qt5
 Summary:    Qt Messaging Framework (QMF) Qt5
-Version:    4.0.4+git13
+Version:    4.0.4+git17
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1 with exception or GPLv3


### PR DESCRIPTION
Keeps reading available data from the socket even if not a entire line is available,
this way readyRead signals will be emitted when new data arrives in the socket.
