### PR TITLE
[qmf] Prevents POP3/SMTP incoming data read from stopping when handling large requests

### DIFF
--- a/qmf/src/plugins/messageservices/pop/popclient.h
+++ b/qmf/src/plugins/messageservices/pop/popclient.h
@@ -99,6 +99,7 @@ public:
 #endif
 
 signals:
+    void connectionError(QMailServiceAction::Status::ErrorCode status, const QString &msg);
     void errorOccurred(int, const QString &);
     void errorOccurred(QMailServiceAction::Status::ErrorCode, const QString &);
     void updateStatus(const QString &);
@@ -138,7 +139,6 @@ private:
     void sendCommand(const char *data, int len = -1);
     void sendCommand(const QString& cmd);
     void sendCommand(const QByteArray& cmd);
-    QString readResponse();
     void processResponse(const QString &response);
     void nextAction();
     void retrieveOperationCompleted();
@@ -184,6 +184,7 @@ private:
     LongStream *dataStream;
 
     QMailTransport *transport;
+    QByteArray lineBuffer;
 
     QString retrieveUid;
 

--- a/qmf/src/plugins/messageservices/smtp/smtpclient.h
+++ b/qmf/src/plugins/messageservices/smtp/smtpclient.h
@@ -88,6 +88,7 @@ public:
     QMailServiceAction::Status::ErrorCode addMail(const QMailMessage& mail);
 
 signals:
+    void connectionError(QMailServiceAction::Status::ErrorCode status, const QString &msg);
     void errorOccurred(int, const QString &);
     void errorOccurred(const QMailServiceAction::Status &, const QString &);
     void updateStatus(const QString &);
@@ -151,6 +152,7 @@ private:
     int outstandingResponses;
     QStringList::Iterator it;
     QMailTransport *transport;
+    QByteArray lineBuffer;
 
     // SendMap maps id -> (units) to be sent
     typedef QMap<QMailMessageId, uint> SendMap;


### PR DESCRIPTION
Keeps reading available data from the socket even if not a entire line is available,
this way readyRead signals will be emitted when new data arrives in the socket.
