### PR TITLE
Fix memory leak

### DIFF
--- a/qmf/src/tools/messageserver/newcountnotifier.cpp
+++ b/qmf/src/tools/messageserver/newcountnotifier.cpp
@@ -55,8 +55,7 @@ NewCountNotifier::~NewCountNotifier()
 
 bool NewCountNotifier::notify()
 {
-    //uncomment the next line to ensure a response is returned, this will cause the QMailMessage::New flag to be unset for all messages
-    //emit response(true);
+    emit response(false);
     return true;
 }
 


### PR DESCRIPTION
NewCountNotifier was never deleted because it never emitted any signals:

==26643== 480 (40 direct, 440 indirect) bytes in 1 blocks are definitely lost in loss record 2,082 of 2,146
==26643==    at 0x4838424: operator new(unsigned int) (vg_replace_malloc.c:292)
==26643==    by 0x4DCD80F: QMetaObjectPrivate::connect(QObject const_, int, QMetaObject const_, QObject const_, int, QMetaObject const_, int, int_) (qobject.cpp:3141)
==26643==    by 0x4DD0C47: QObject::connect(QObject const_, char const_, QObject const_, char const_, Qt::ConnectionType) (qobject.cpp:2610)
==26643==    by 0x18CA3: MessageServer::reportNewCounts() (messageserver.cpp:380)
==26643==    by 0x50A17: MessageServer::qt_static_metacall(QObject_, QMetaObject::Call, int, void**) (moc_messageserver.cpp:126)
==26643==    by 0x4DCC43F: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3580)
==26643==    by 0x5255B: ServiceHandler::qt_static_metacall(QObject_, QMetaObject::Call, int, void__) (moc_servicehandler.cpp:509)
==26643==    by 0x4DCC43F: QMetaObject::activate(QObject_, int, int, void**) (qobject.cpp:3580)
==26643==    by 0x4DCC43F: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3580)
==26643==    by 0x8905173: ImapClient::retrieveOperationCompleted() (imapclient.cpp:1735)
==26643==    by 0x895C707: ImapStrategyContextBase::operationCompleted() (imapstrategy.cpp:480)
==26643==    by 0x8962313: ImapRetrieveMessageListStrategy::messageListCompleted(ImapStrategyContextBase*) (imapstrategy.cpp:1345)
