### PR TITLE
[systemd] Do not try to restart messageserver when there are no accounts...

### DIFF
--- a/qmf/src/tools/accountscheck/accountscheck.pro
+++ b/qmf/src/tools/accountscheck/accountscheck.pro
@@ -13,7 +13,8 @@ LIBS += -L../../libraries/qmfclient/build
 SOURCES += accountscheck.cpp
 
 # Target to install systemd service file
-systemd.files = ../systemd/messageserver5.service
+systemd.files = ../systemd/messageserver5.service \
+		../systemd/messageserver5-accounts-check.service
 systemd.path= /usr/lib/systemd/user/
 
 INSTALLS+= target systemd

--- a/qmf/src/tools/systemd/messageserver5-accounts-check.service
+++ b/qmf/src/tools/systemd/messageserver5-accounts-check.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=check accounts for messageserver5
+Before=messageserver5.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/qmf-accountscheck
+
+[Install]
+WantedBy=user-session.target

--- a/qmf/src/tools/systemd/messageserver5.service
+++ b/qmf/src/tools/systemd/messageserver5.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=messageserver5
-Requires=booster-generic.service 
+Requires=messageserver5-accounts-check.service
+Requires=booster-generic.service
 After=booster-generic.service
+After=messageserver5-accounts-check.service
 
 [Service]
 Type=simple
-ExecStartPre=/usr/bin/qmf-accountscheck
 ExecStart=/usr/bin/invoker -o --type=generic --global-syms /usr/bin/messageserver5
 Restart=on-failure
 RestartSec=1

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -144,6 +144,7 @@ rm -rf %{buildroot}
 UNIT_DIR=%{buildroot}%{_libdir}/systemd/user/user-session.target.wants
 mkdir -p "$UNIT_DIR"
 ln -sf ../messageserver5.service "$UNIT_DIR/messageserver5.service"
+ln -sf ../messageserver5-accounts-check.service "$UNIT_DIR/messageserver5-accounts-check.service"
 
 # >> install post
 # << install post
@@ -187,7 +188,9 @@ ln -sf ../messageserver5.service "$UNIT_DIR/messageserver5.service"
 %{_libdir}/qmf/plugins5/messageservices/libqmfsettings.so
 %{_libdir}/qmf/plugins5/messageservices/libsmtp.so
 %{_libdir}/systemd/user/messageserver5.service
+%{_libdir}/systemd/user/messageserver5-accounts-check.service
 %{_libdir}/systemd/user/user-session.target.wants/messageserver5.service
+%{_libdir}/systemd/user/user-session.target.wants/messageserver5-accounts-check.service
 # << files libqmfmessageserver1-qt5
 
 %files -n libqmfclient1-qt5


### PR DESCRIPTION
.... Fixes: JB#12100

Split off the accounts check to its own .service file so we do not try
to restart messageserver several times. Also now the accounts check works
and when there are no accounts configured we do not start the messageserver.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
