### PR TITLE
[qmf] fix read status sync error on large batches

### DIFF
--- a/qmf/src/libraries/qmfclient/qmailstore_p.cpp
+++ b/qmf/src/libraries/qmfclient/qmailstore_p.cpp
@@ -8050,6 +8050,7 @@ QMailStorePrivate::AttemptResult QMailStorePrivate::attemptUpdateMessagesStatus(
 
         // perhaps, we need to update unreadcount column or status column in mailthreads table
         QVariantList bindMessagesIds;
+        QVariantList bindMessagesIdsBatch;
             foreach (const QMailMessageId& id, *updatedMessageIds)
             {
                 const QMailThreadId &threadId = QMailMessageMetaData(id).parentThreadId();
@@ -8061,18 +8062,27 @@ QMailStorePrivate::AttemptResult QMailStorePrivate::attemptUpdateMessagesStatus(
             foreach (const QMailThreadId& threadId, *modifiedThreadIds)
             {
                 if (threadId.isValid()) {
-                    QString sql("SELECT status FROM mailmessages WHERE id IN %1 and parentthreadid = %2");
 
-                    QSqlQuery query(simpleQuery(sql.arg(expandValueList(bindMessagesIds)).arg(threadId.toULongLong()),
-                                                bindMessagesIds,
-                                                "status mailmessages query"));
-                    if (query.lastError().type() != QSqlError::NoError)
-                        return DatabaseFailure;
                     QList<quint64> oldStatusList;
 
-                    while (query.next())
-                        oldStatusList.append(query.value(0).toULongLong());
+                    while (!bindMessagesIds.isEmpty()) {
+                        bindMessagesIdsBatch.clear();
+                        bindMessagesIdsBatch = bindMessagesIds.mid(0,500);
+                        if (bindMessagesIds.count() > 500) {
+                            bindMessagesIds = bindMessagesIds.mid(500);
+                        } else {
+                            bindMessagesIds.clear();
+                        }
+                        QString sql("SELECT status FROM mailmessages WHERE id IN %1 and parentthreadid = %2");
+                        QSqlQuery query(simpleQuery(sql.arg(expandValueList(bindMessagesIdsBatch)).arg(threadId.toULongLong()),
+                                                    bindMessagesIdsBatch,
+                                                    "status mailmessages query"));
+                        if (query.lastError().type() != QSqlError::NoError)
+                            return DatabaseFailure;
 
+                        while (query.next())
+                            oldStatusList.append(query.value(0).toULongLong());
+                    }
                     qlonglong unreadCount = 0;
                     foreach (const quint64& oldStatus, oldStatusList)
                     {


### PR DESCRIPTION
Updating thousands of read statuses leads to "too many SQL variables" error, similar fix was done in here: https://qt.gitorious.org/qt-labs/messagingframework/commit/4256ae33a7b5406d505968235f94d07f6510edf6
