### PR TITLE
Fixed a crash in PopClient::incomingData

### DIFF
--- a/qmf/src/plugins/messageservices/pop/popclient.cpp
+++ b/qmf/src/plugins/messageservices/pop/popclient.cpp
@@ -502,7 +502,7 @@ void PopClient::incomingData()
         processResponse(response);
     }
 
-    if (transport->bytesAvailable()) {
+    if (transport && transport->bytesAvailable()) {
         // If there is an incomplete line, read it from the socket buffer to ensure we get readyRead signal next time
         lineBuffer.append(transport->readAll());
     }


### PR DESCRIPTION
Transport may be deleted by processResponse/operationFailed, have to check it after processResponse returns. That happens, for instance, if invalid credentials were provided.
