### PR TITLE
[qmf] Add keepalive timer to IMAP IDLE service

### DIFF
--- a/qmf/src/plugins/messageservices/imap/imap.pro
+++ b/qmf/src/plugins/messageservices/imap/imap.pro
@@ -21,6 +21,10 @@ equals(QT_MAJOR_VERSION, 5) {
 
 QT = core network
 
+contains(DEFINES, USE_KEEPALIVE) {
+    PKGCONFIG += keepalive
+}
+
 contains(DEFINES,QT_QMF_USE_ALIGNEDTIMER) {
     QT += alignedtimer
 }

--- a/qmf/src/plugins/messageservices/imap/imapclient.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapclient.cpp
@@ -347,7 +347,7 @@ private:
 
 #ifdef USE_ACCOUNTS_QT
 IdleProtocol::IdleProtocol(ImapClient *client, const QMailFolder &folder, const bool ssoAccount, QByteArray &ssoLogin)
-    :_idleRetryDelay(InitialIdleRetryDelay),
+    : _idleRetryDelay(InitialIdleRetryDelay),
       _ssoAccount(ssoAccount),
       _ssoLogin(ssoLogin)
 {
@@ -2099,6 +2099,9 @@ void ImapClient::closeIdleConnections()
     qMailLog(IMAP) << Q_FUNC_INFO << "Account was modified. Closing connections";
 
     closeConnection();
+#ifdef USE_KEEPALIVE
+    emit stopPushEmail();
+#endif
     // closing idle connections
     foreach(const QMailFolderId &id, _monitored.keys()) {
         IdleProtocol *protocol = _monitored.take(id);

--- a/qmf/src/plugins/messageservices/imap/imapclient.h
+++ b/qmf/src/plugins/messageservices/imap/imapclient.h
@@ -59,6 +59,9 @@
 #include <ssosessionmanager.h>
 #endif
 
+#ifdef USE_KEEPALIVE
+#include <keepalive/backgroundactivity.h>
+#endif
 
 class ImapStrategy;
 class ImapStrategyContext;
@@ -115,6 +118,9 @@ signals:
     void errorOccurred(QMailServiceAction::Status::ErrorCode, const QString &);
     void updateStatus(const QString &);
     void restartPushEmail();
+#ifdef USE_KEEPALIVE
+    void stopPushEmail();
+#endif
 
     void progressChanged(uint, uint);
     void retrievalCompleted();

--- a/qmf/src/plugins/messageservices/imap/imapservice.h
+++ b/qmf/src/plugins/messageservices/imap/imapservice.h
@@ -76,8 +76,12 @@ protected slots:
     virtual void accountsUpdated(const QMailAccountIdList &ids);
     void errorOccurred(int code, const QString &text);
     void errorOccurred(QMailServiceAction::Status::ErrorCode code, const QString &text);
-
     void updateStatus(const QString& text);
+
+#ifdef USE_KEEPALIVE
+    void onUpdateLastSyncTime();
+    void stopPushEmail();
+#endif
 
 private:
     class Source;
@@ -96,6 +100,11 @@ private:
     enum { ThirtySeconds = 30 };
     static QMap<QMailAccountId, int> _initiatePushDelay; // Limit battery consumption
     QTimer *_initiatePushEmailTimer;
+#ifdef USE_KEEPALIVE
+    BackgroundActivity* _backgroundActivity;
+    int _lastSyncCounter;
+    bool _idling;
+#endif
 };
 
 class ImapServicePlugin : public QMailMessageServicePlugin

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -1,6 +1,6 @@
 Name: qmf-qt5
 Summary:    Qt Messaging Framework (QMF) Qt5
-Version:    4.0.4+git27
+Version:    4.0.4+git28
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1 with exception or GPLv3
@@ -17,6 +17,7 @@ BuildRequires: 	pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Sql)
 BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(libsignon-qt5)
+BuildRequires:  pkgconfig(keepalive)
 #Needed for qhelpgenerator
 BuildRequires:  qt5-qttools-qthelp-devel
 BuildRequires:  qt5-plugin-platform-minimal
@@ -129,6 +130,7 @@ This package contains the documentation for Qt Messaging Framework (QMF).
     DEFINES+=QMF_ENABLE_LOGGING \
     DEFINES+=MESSAGESERVER_PLUGINS \
     DEFINES+=QMF_NO_MESSAGE_SERVICE_EDITOR \
+    DEFINES+=USE_KEEPALIVE \
     CONFIG+=syslog
 
 make %{?_smp_mflags}


### PR DESCRIPTION
This commit introduce a dependency on nemo-keepalive via
DEFINES+=USE_KEEPALIVE
