### PR TITLE
[qmf] Fix  tst_QMailStoreKeys() test cases.

### DIFF
--- a/qmf/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
+++ b/qmf/tests/tst_qmailstorekeys/tst_qmailstorekeys.cpp
@@ -2381,35 +2381,35 @@ void tst_QMailStoreKeys::listModel()
     QCOMPARE(model.idFromIndex(model.index(3, 0)), inboxMessage2);
     QCOMPARE(model.idFromIndex(model.index(4, 0)), savedMessage2);
 
-    // Sort by descending subject - note majuscules sort before miniscules
+    // Sort by descending subject - Not case sensitive since 096c2638589b7c071306b460796daddf30bf47e7
     model.setKey(QMailMessageKey());
     model.setSortKey(QMailMessageSortKey::subject(Qt::DescendingOrder));
 
-    QCOMPARE(model.indexFromId(inboxMessage1).row(), 0);
-    QCOMPARE(model.indexFromId(archivedMessage1).row(), 1);
-    QCOMPARE(model.indexFromId(smsMessage).row(), 2);
-    QCOMPARE(model.indexFromId(savedMessage2).row(), 3);
-    QCOMPARE(model.indexFromId(inboxMessage2).row(), 4);
+    QCOMPARE(model.indexFromId(smsMessage).row(), 0);
+    QCOMPARE(model.indexFromId(savedMessage2).row(), 1);
+    QCOMPARE(model.indexFromId(inboxMessage1).row(), 2);
+    QCOMPARE(model.indexFromId(inboxMessage2).row(), 3);
+    QCOMPARE(model.indexFromId(archivedMessage1).row(), 4);
 
     QCOMPARE(model.rowCount(), 5);
 
-    QCOMPARE(model.idFromIndex(model.index(0, 0)), inboxMessage1);
-    QCOMPARE(model.idFromIndex(model.index(1, 0)), archivedMessage1);
-    QCOMPARE(model.idFromIndex(model.index(2, 0)), smsMessage);
-    QCOMPARE(model.idFromIndex(model.index(3, 0)), savedMessage2);
-    QCOMPARE(model.idFromIndex(model.index(4, 0)), inboxMessage2);
+    QCOMPARE(model.idFromIndex(model.index(0, 0)), smsMessage);
+    QCOMPARE(model.idFromIndex(model.index(1, 0)), savedMessage2);
+    QCOMPARE(model.idFromIndex(model.index(2, 0)), inboxMessage1);
+    QCOMPARE(model.idFromIndex(model.index(3, 0)), inboxMessage2);
+    QCOMPARE(model.idFromIndex(model.index(4, 0)), archivedMessage1);
 
     // Only display messages from inbox1, or with a response type
     model.setKey(QMailMessageKey::parentFolderId(inboxId1) | QMailMessageKey::responseType(QMailMessage::NoResponse, QMailDataComparator::NotEqual));
 
-    QCOMPARE(model.indexFromId(inboxMessage1).row(), 0);
-    QCOMPARE(model.indexFromId(savedMessage2).row(), 1);
+    QCOMPARE(model.indexFromId(savedMessage2).row(), 0);
+    QCOMPARE(model.indexFromId(inboxMessage1).row(), 1);
     QCOMPARE(model.indexFromId(inboxMessage2).row(), 2);
 
     QCOMPARE(model.rowCount(), 3);
 
-    QCOMPARE(model.idFromIndex(model.index(0, 0)), inboxMessage1);
-    QCOMPARE(model.idFromIndex(model.index(1, 0)), savedMessage2);
+    QCOMPARE(model.idFromIndex(model.index(0, 0)), savedMessage2);
+    QCOMPARE(model.idFromIndex(model.index(1, 0)), inboxMessage1);
     QCOMPARE(model.idFromIndex(model.index(2, 0)), inboxMessage2);
 }
 
@@ -2438,40 +2438,40 @@ void tst_QMailStoreKeys::threadedModel()
     QCOMPARE(model.idFromIndex(model.index(0, 0, model.indexFromId(inboxMessage1))), inboxMessage2);
     QCOMPARE(model.idFromIndex(model.index(0, 0, model.indexFromId(archivedMessage1))), savedMessage2);
 
-    // Sort by descending subject - note majuscules sort before miniscules
+    // Sort by descending subject - Not case sensitive since 096c2638589b7c071306b460796daddf30bf47e7
     model.setKey(QMailMessageKey());
     model.setSortKey(QMailMessageSortKey::subject(Qt::DescendingOrder));
 
-    QCOMPARE(model.indexFromId(inboxMessage1).row(), 0);
-    QCOMPARE(model.indexFromId(archivedMessage1).row(), 1);
-    QCOMPARE(model.indexFromId(smsMessage).row(), 2);
+    QCOMPARE(model.indexFromId(smsMessage).row(), 0);
+    QCOMPARE(model.indexFromId(inboxMessage1).row(), 1);
+    QCOMPARE(model.indexFromId(archivedMessage1).row(), 2);
     QCOMPARE(model.indexFromId(inboxMessage2).row(), 0);
-    QCOMPARE(model.indexFromId(inboxMessage2).parent().row(), 0);
+    QCOMPARE(model.indexFromId(inboxMessage2).parent().row(), 1);
     QCOMPARE(model.indexFromId(savedMessage2).row(), 0);
-    QCOMPARE(model.indexFromId(savedMessage2).parent().row(), 1);
+    QCOMPARE(model.indexFromId(savedMessage2).parent().row(), 2);
 
     QCOMPARE(model.rowCount(), 3);
     QCOMPARE(model.rowCount(model.indexFromId(inboxMessage1)), 1);
     QCOMPARE(model.rowCount(model.indexFromId(archivedMessage1)), 1);
 
-    QCOMPARE(model.idFromIndex(model.index(0, 0)), inboxMessage1);
-    QCOMPARE(model.idFromIndex(model.index(1, 0)), archivedMessage1);
-    QCOMPARE(model.idFromIndex(model.index(2, 0)), smsMessage);
+    QCOMPARE(model.idFromIndex(model.index(0, 0)), smsMessage);
+    QCOMPARE(model.idFromIndex(model.index(1, 0)), inboxMessage1);
+    QCOMPARE(model.idFromIndex(model.index(2, 0)), archivedMessage1);
     QCOMPARE(model.idFromIndex(model.index(0, 0, model.indexFromId(inboxMessage1))), inboxMessage2);
     QCOMPARE(model.idFromIndex(model.index(0, 0, model.indexFromId(archivedMessage1))), savedMessage2);
 
     // Only display messages from inbox1, or with a response type
     model.setKey(QMailMessageKey::parentFolderId(inboxId1) | QMailMessageKey::responseType(QMailMessage::NoResponse, QMailDataComparator::NotEqual));
 
-    QCOMPARE(model.indexFromId(inboxMessage1).row(), 0);
-    QCOMPARE(model.indexFromId(savedMessage2).row(), 1);
+    QCOMPARE(model.indexFromId(savedMessage2).row(), 0);
+    QCOMPARE(model.indexFromId(inboxMessage1).row(), 1);
     QCOMPARE(model.indexFromId(inboxMessage2).row(), 0);
-    QCOMPARE(model.indexFromId(inboxMessage2).parent().row(), 0);
+    QCOMPARE(model.indexFromId(inboxMessage2).parent().row(), 1);
 
     QCOMPARE(model.rowCount(), 2);
     QCOMPARE(model.rowCount(model.indexFromId(inboxMessage1)), 1);
 
-    QCOMPARE(model.idFromIndex(model.index(0, 0)), inboxMessage1);
-    QCOMPARE(model.idFromIndex(model.index(1, 0)), savedMessage2);
+    QCOMPARE(model.idFromIndex(model.index(0, 0)), savedMessage2);
+    QCOMPARE(model.idFromIndex(model.index(1, 0)), inboxMessage1);
     QCOMPARE(model.idFromIndex(model.index(0, 0, model.indexFromId(inboxMessage1))), inboxMessage2);
 }


### PR DESCRIPTION
Since 096c2638589b7c071306b460796daddf30bf47e7 fields which are matched
case-insensitive are also sorted similarly.
