### PR TITLE
Initialize (at least) some ImapFetchSelectedMessagesStrategy variables

### DIFF
--- a/qmf/src/plugins/messageservices/imap/imapstrategy.h
+++ b/qmf/src/plugins/messageservices/imap/imapstrategy.h
@@ -302,7 +302,7 @@ protected:
 class ImapFetchSelectedMessagesStrategy : public ImapMessageListStrategy
 {
 public:
-    ImapFetchSelectedMessagesStrategy() {}
+    ImapFetchSelectedMessagesStrategy() : _listSize(0), _totalRetrievalSize(0) {}
     virtual ~ImapFetchSelectedMessagesStrategy() {}
     
     virtual void setOperation(ImapStrategyContextBase *context,


### PR DESCRIPTION
I think it's generally a good idea to initialize instance variables. Regarding this particular class, valgrind reports that uninitialized instance variables are actually being used sometimes:

==2089== Conditional jump or move depends on uninitialised value(s)
==2089==    at 0x4C4CF6C: qulltoa(unsigned long long, int, QChar) (qlocale_tools.cpp:85)
==2089==    by 0x4C4D08B: qlltoa(long long, int, QChar) (qlocale_tools.cpp:113)
==2089==    by 0x4C4472F: QLocalePrivate::longLongToString(QChar, QChar, QChar, QChar, long long, int, int, int, unsigned int) (qlocale.cpp:2954)
==2089==    by 0x4C4493F: QLocalePrivate::longLongToString(long long, int, int, int, unsigned int) const (qlocale.cpp:2929)
==2089==    by 0x4C7C3A7: QString::arg(long long, int, int, QChar) const (qstring.cpp:7149)
==2089==    by 0x894B723: ImapFetchSelectedMessagesStrategy::itemFetched(ImapStrategyContextBase_, QString const&) (qstring.h:784)
==2089==    by 0x895680F: ImapFetchSelectedMessagesStrategy::messageFetched(ImapStrategyContextBase_, QMailMessage&) (imapstrategy.cpp:1700)
==2089==    by 0x895696B: ImapCopyMessagesStrategy::messageFetched(ImapStrategyContextBase_, QMailMessage&) (imapstrategy.cpp:3988)
==2089==    by 0x8907193: ImapClient::messageFetched(QMailMessage&, QString const&, bool) (imapstrategy.h:853)
==2089==    by 0x8973D2F: ImapClient::qt_static_metacall(QObject_, QMetaObject::Call, int, void**) (moc_imapclient.cpp:256)
==2089==    by 0x4DC543F: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3580)
==2089==    by 0x897602F: ImapProtocol::messageFetched(QMailMessage&, QString const&, bool) (moc_imapprotocol.cpp:421)
==2089==    by 0x892669F: ImapProtocol::createMail(QString const&, QDateTime const&, int, unsigned int, QString const&, QStringList const&) (imapprotocol.cpp:3699)
==2089==    by 0x8926F07: UidFetchState::untaggedResponse(ImapContext_, QString const&) (imapprotocol.cpp:330)
==2089==    by 0x8925357: ImapProtocol::nextAction(QString const&) (imapprotocol.cpp:2752)
==2089==    by 0x8925B6B: ImapProtocol::processResponse(QString) (imapprotocol.cpp:3484)
==2089==    by 0x89262E7: ImapProtocol::incomingData() (imapprotocol.cpp:3323)
==2089==    by 0x89763D7: ImapProtocol::qt_static_metacall(QObject_, QMetaObject::Call, int, void**) (moc_imapprotocol.cpp:209)
==2089==    by 0x4DC543F: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3580)
==2089==    by 0x48832DB: QMailTransport::qt_static_metacall(QObject_, QMetaObject::Call, int, void__) (moc_qmailtransport.cpp:126)
==2089==    by 0x4DC543F: QMetaObject::activate(QObject_, int, int, void**) (qobject.cpp:3580)
==2089==    by 0x5337C27: QSslSocketBackendPrivate::transmit() (qsslsocket_openssl.cpp:941)
==2089==    by 0x532B68F: QSslSocketPrivate::_q_readyReadSlot() (qsslsocket.cpp:2282)
==2089==    by 0x533236F: QSslSocket::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_qsslsocket.cpp:156)
==2089==    by 0x4DC543F: QMetaObject::activate(QObject_, int, int, void__) (qobject.cpp:3580)
==2089==    by 0x530591B: QAbstractSocketPrivate::canReadNotification() (qabstractsocket.cpp:726)
==2089==    by 0x52F85FB: QAbstractSocketEngine::readNotification() (qabstractsocketengine.cpp:156)
==2089==    by 0x5314BDB: QReadNotifier::event(QEvent_) (qnativesocketengine.cpp:1147)
==2089==    by 0x4D91053: QCoreApplicationPrivate::notify_helper(QObject_, QEvent_) (qcoreapplication.cpp:1003)
==2089==    by 0x4D91123: QCoreApplication::notify(QObject_, QEvent_) (qcoreapplication.cpp:948)
