### PR TITLE
[qmf] Add QMailMessagePartContainer::findInlinePartLocations()

### DIFF
--- a/qmf/src/libraries/qmfclient/qmailmessage.cpp
+++ b/qmf/src/libraries/qmfclient/qmailmessage.cpp
@@ -914,6 +914,7 @@ namespace findBody
         QMailMessagePartContainer *alternateParent;
         QList<QMailMessagePart::Location> htmlImageLoc;
         QList<const QMailMessagePart *> htmlImageParts;
+        QList<QMailMessagePart::Location> htmlExtraPartsLoc;
         QByteArray contentType;
         QByteArray contentSubtype;
     };
@@ -1019,9 +1020,13 @@ namespace findBody
         for (int i = (int)container.partCount() - 1; i >= 0; i--) {
             if (i != bodyPart) {
                 const QMailMessagePart &part = container.partAt(i);
-                if (imageContentType == part.contentType().type().toLower())
+                if (imageContentType == part.contentType().type().toLower()) {
                     ctx.htmlImageLoc << part.location();
                     ctx.htmlImageParts << &part;
+                } else if (!part.contentID().isEmpty()) {
+                    // Adding extra inline part
+                    ctx.htmlExtraPartsLoc << part.location();
+                }
             }
         }
 
@@ -5096,7 +5101,10 @@ QList<QMailMessagePart::Location> QMailMessagePartContainer::findAttachmentLocat
 }
 
 /*!
-  Returns the locations of the attachments in a container, dealing with a range of different message structures and exceptions.
+  Returns the locations of the inline images in a HTML body container, only parts with content type "image" will be returned.
+  Note that sometimes inline images content type is not defined or is other than "image".
+
+  \sa findInlinePartLocations()
  */
 QList<QMailMessagePart::Location> QMailMessagePartContainer::findInlineImageLocations() const
 {
@@ -5104,6 +5112,20 @@ QList<QMailMessagePart::Location> QMailMessagePartContainer::findInlineImageLoca
     ctx.contentSubtype = htmlContentSubtype;
     if (findBody::inPartContainer(*this, ctx)) {
         return ctx.htmlImageLoc;
+    } else {
+        return QList<QMailMessagePart::Location>();
+    }
+}
+
+/*!
+  Returns the locations of the inline parts in a HTML body container, only parts with a content id reference will be returned.
+ */
+QList<QMailMessagePart::Location> QMailMessagePartContainer::findInlinePartLocations() const
+{
+    findBody::Context ctx;
+    ctx.contentSubtype = htmlContentSubtype;
+    if (findBody::inPartContainer(*this, ctx)) {
+        return ctx.htmlImageLoc << ctx.htmlExtraPartsLoc;
     } else {
         return QList<QMailMessagePart::Location>();
     }

--- a/qmf/src/libraries/qmfclient/qmailmessage.h
+++ b/qmf/src/libraries/qmfclient/qmailmessage.h
@@ -386,6 +386,7 @@ public:
     QMailMessagePartContainer* findHtmlContainer() const;
     QList<QMailMessagePartContainer::Location> findAttachmentLocations() const;
     QList<QMailMessagePartContainer::Location> findInlineImageLocations() const;
+    QList<QMailMessagePartContainer::Location> findInlinePartLocations() const;
     bool hasPlainTextBody() const;
     bool hasHtmlBody() const;
     bool hasAttachments() const;

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -1,6 +1,6 @@
 Name: qmf-qt5
 Summary:    Qt Messaging Framework (QMF) Qt5
-Version:    4.0.4+git32
+Version:    4.0.4+git33
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1 with exception or GPLv3


### PR DESCRIPTION
QMailMessagePartContainer::findInlinePartLocations() returns the locations of the inline parts
in a HTML body container, only parts with a content id reference will be returned.
