### PR TITLE
[qmf] Introduce QMailAccount::AlwaysOnMode status flag

### DIFF
--- a/qmf/src/libraries/qmfclient/qmailaccount.cpp
+++ b/qmf/src/libraries/qmfclient/qmailaccount.cpp
@@ -68,6 +68,7 @@ static quint64 canTransmitViaReferenceFlag = 0;
 static quint64 canCreateFoldersFlag = 0;
 static quint64 useSmartReplyFlag = 0;
 static quint64 canSearchOnServerFlag = 0;
+static quint64 hasPersistentConnectionFlag = 0;
 
 class QMailAccountPrivate : public QSharedData
 {
@@ -352,6 +353,15 @@ public:
     \sa QMailSearchAction::searchMessages()
 */
 
+/*!
+    \variable QMailAccount::HasPersistentConnection
+
+    The status mask needed for testing the value of the registered status flag named
+    \c "HasPersistentConnection" against the result of QMailAccount::status().
+
+    This flag indicates that an account has a persistent connection to the server(always online).
+*/
+
 const quint64 &QMailAccount::SynchronizationEnabled = synchronizationEnabledFlag;
 const quint64 &QMailAccount::Synchronized = synchronizedFlag;
 const quint64 &QMailAccount::AppendSignature = appendSignatureFlag;
@@ -368,6 +378,7 @@ const quint64 &QMailAccount::CanTransmitViaReference = canTransmitViaReferenceFl
 const quint64 &QMailAccount::CanCreateFolders = canCreateFoldersFlag;
 const quint64 &QMailAccount::UseSmartReply = useSmartReplyFlag;
 const quint64 &QMailAccount::CanSearchOnServer = canSearchOnServerFlag;
+const quint64 &QMailAccount::HasPersistentConnection = hasPersistentConnectionFlag;
 
 /*!
     Creates an uninitialised account object.

--- a/qmf/src/libraries/qmfclient/qmailaccount.h
+++ b/qmf/src/libraries/qmfclient/qmailaccount.h
@@ -84,6 +84,7 @@ public:
     static const quint64 &CanCreateFolders;
     static const quint64 &UseSmartReply;
     static const quint64 &CanSearchOnServer;
+    static const quint64 &HasPersistentConnection;
 
     QMailAccount();
     explicit QMailAccount(const QMailAccountId& id);

--- a/qmf/src/plugins/messageservices/imap/imapservice.h
+++ b/qmf/src/plugins/messageservices/imap/imapservice.h
@@ -79,7 +79,6 @@ protected slots:
     void updateStatus(const QString& text);
 
 #ifdef USE_KEEPALIVE
-    void onUpdateLastSyncTime();
     void stopPushEmail();
 #endif
 
@@ -102,8 +101,6 @@ private:
     QTimer *_initiatePushEmailTimer;
 #ifdef USE_KEEPALIVE
     BackgroundActivity* _backgroundActivity;
-    int _lastSyncCounter;
-    bool _idling;
 #endif
 };
 


### PR DESCRIPTION
Use QMailAccount::AlwaysOnMode status flag for IMAP idle instead of
updating last sync time every minute, this reduces accounts db writes(they
trigger notifications to other processes) and also make use of a linger
keepalive(less state transitions).
