### PR TITLE
[qmf] Update to libaccounts-qt version 1.13

### DIFF
--- a/qmf/src/libraries/qmfclient/ssosessionmanager.cpp
+++ b/qmf/src/libraries/qmfclient/ssosessionmanager.cpp
@@ -132,7 +132,7 @@ bool SSOSessionManager::createSsoIdentity(const QMailAccountId &id, const QStrin
     _accountId = id.toULongLong();
 
     SSOAccountManager manager;
-    QScopedPointer<Accounts::Account> account(manager->account(static_cast<Accounts::AccountId>(_accountId)));
+    QScopedPointer<Accounts::Account> account(Accounts::Account::fromId(manager, static_cast<Accounts::AccountId>(_accountId), this));
     if (!account)
         return false;
 

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires: 	pkgconfig(Qt5Network)
 #BuildRequires: pkgconfig(Qt5Webkit)
 BuildRequires:  pkgconfig(Qt5Sql)
-BuildRequires:  pkgconfig(accounts-qt5)
+BuildRequires:  pkgconfig(accounts-qt5) >= 1.13
 BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(keepalive)
 BuildRequires:  pkgconfig(qt5-boostable)


### PR DESCRIPTION
This commit ensures that we use the Accounts::Account::fromId()
function instead of Accounts::Manager::account() function to
retrieve an account instance, to ensure that we can delete
the returned account instance without causing crashes, due
to a change in version 1.7 of libaccounts-qt.