### PR TITLE
[qmf] Listen to sync schedule changes from buteo sync framework.

### DIFF
--- a/qmf/src/plugins/messageservices/imap/imap.pro
+++ b/qmf/src/plugins/messageservices/imap/imap.pro
@@ -23,6 +23,7 @@ QT = core network
 
 contains(DEFINES, USE_KEEPALIVE) {
     PKGCONFIG += keepalive
+    QT += dbus
 }
 
 contains(DEFINES,QT_QMF_USE_ALIGNEDTIMER) {

--- a/qmf/src/plugins/messageservices/imap/imapclient.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapclient.cpp
@@ -2026,7 +2026,7 @@ bool ImapClient::pushEnabled()
 
 void ImapClient::setPushEnabled(bool state)
 {
-    if (_pushEnabled != state) {
+    if (pushEnabled() != state) {
         qMailLog(Messaging) << Q_FUNC_INFO << "Setting push enabled state to " << state;
         _pushEnabled = state;
     }
@@ -2088,8 +2088,7 @@ void ImapClient::onSsoSessionResponse(const QMap<QString,QList<QByteArray> > &ss
     }
     if (_sendLogin) {
         _protocol.sendLogin(_config, _ssoLogin);
-    }
-    if (_waitingForIdle) {
+    } else if (_waitingForIdle) {
         monitor(_waitingForIdleFolderIds);
     }
 }

--- a/qmf/src/plugins/messageservices/imap/imapclient.h
+++ b/qmf/src/plugins/messageservices/imap/imapclient.h
@@ -79,7 +79,6 @@ public:
     void setAccount(const QMailAccountId& accountId);
 #ifdef USE_ACCOUNTS_QT
     void removeSsoIdentity(const QMailAccountId& accountId);
-    void closeIdleConnections();
 #endif
     QMailAccountId account() const;
     void requestRapidClose() { _requestRapidClose = true; } // Close connection ASAP, unless interactive checking occurred recently
@@ -87,6 +86,7 @@ public:
     void newConnection();
     void cancelTransfer(QMailServiceAction::Status::ErrorCode code, const QString &text);
     void closeConnection();
+    void closeIdleConnections();
 
     ImapStrategyContext *strategyContext();
 
@@ -113,6 +113,8 @@ public:
     void setPushConnectionsReserved(int reserved) { _pushConnectionsReserved = reserved; }
     int idleRetryDelay() const { return _idleRetryDelay; }
     void setIdleRetryDelay(int delay) { _idleRetryDelay = delay; }
+    bool pushEnabled();
+    void setPushEnabled(bool state);
 
 signals:
     void errorOccurred(int, const QString &);
@@ -208,6 +210,7 @@ private:
     QList<QMailMessageBufferFlushCallback*> callbacks;
     QVector<QMailMessage*> _bufferedMessages;
     int _pushConnectionsReserved;
+    bool _pushEnabled;
 
     QMap<QMailMessageId,QString> detachedTempFiles;
 

--- a/qmf/src/plugins/messageservices/imap/imapservice.h
+++ b/qmf/src/plugins/messageservices/imap/imapservice.h
@@ -80,6 +80,7 @@ protected slots:
 
 #ifdef USE_KEEPALIVE
     void stopPushEmail();
+    void pushEnabledStatus(uint accountId, const QString &profileType, bool state);
 #endif
 
 private:
@@ -101,6 +102,8 @@ private:
     QTimer *_initiatePushEmailTimer;
 #ifdef USE_KEEPALIVE
     BackgroundActivity* _backgroundActivity;
+    bool _accountPushEnabled;
+    bool _buteoReplyReceived;
 #endif
 };
 

--- a/qmf/src/plugins/messageservices/imap/imapservice.h
+++ b/qmf/src/plugins/messageservices/imap/imapservice.h
@@ -79,6 +79,7 @@ protected slots:
     void updateStatus(const QString& text);
 
 #ifdef USE_KEEPALIVE
+    void onUpdateLastSyncTime();
     void stopPushEmail();
     void pushEnabledStatus(uint accountId, const QString &profileType, bool state);
 #endif
@@ -102,6 +103,7 @@ private:
     QTimer *_initiatePushEmailTimer;
 #ifdef USE_KEEPALIVE
     BackgroundActivity* _backgroundActivity;
+    bool _idling;
     bool _accountPushEnabled;
     bool _buteoReplyReceived;
 #endif

--- a/qmf/src/tools/systemd/messageserver5.service
+++ b/qmf/src/tools/systemd/messageserver5.service
@@ -2,7 +2,7 @@
 Description=messageserver5
 Requires=messageserver5-accounts-check.service
 Requires=booster-qt5.service
-After=booster-qt5.service
+After=msyncd.service
 After=messageserver5-accounts-check.service
 
 [Service]

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -11,6 +11,7 @@ BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(icu-i18n)
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires: 	pkgconfig(Qt5Network)
 #BuildRequires: pkgconfig(Qt5Webkit)
@@ -24,6 +25,7 @@ BuildRequires:  qt5-qttools-qthelp-devel
 BuildRequires:  qt5-plugin-platform-minimal
 BuildRequires:  qt5-plugin-sqldriver-sqlite
 BuildRequires:  fdupes
+Requires:       buteo-syncfw-qt5 >= 0.7.14 
 
 %description
 The Qt Messaging Framework, QMF, consists of a C++ library and daemon server


### PR DESCRIPTION
This commit introduces d-bus listeners inside IMAP4 service to
react to changes in the account schedule related to always-on mode
and activate/deactivate IMAP IDLE.