### PR TITLE
[qmf] Set highestmodseq to zero when server using QRESYNC does not support permanent modsequences.

### DIFF
--- a/qmf/src/plugins/messageservices/imap/imapstrategy.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapstrategy.cpp
@@ -3754,7 +3754,7 @@ void ImapRetrieveMessageListStrategy::qresyncFolderListFolderAction(ImapStrategy
     // Always set the highestmodseq for the folder
     {
         processFlagChanges(properties.flagChanges, properties.id, &_error);
-        folder.setCustomField("qmf-highestmodseq", properties.highestModSeq);
+        folder.setCustomField("qmf-highestmodseq", properties.highestModSeq.isEmpty() ? QLatin1String("0") : properties.highestModSeq);
         if (!QMailStore::instance()->updateFolder(&folder)) {
             _error = true;
             qWarning() << "Unable to update folder HIGHESTMODSEQ for account:" << context->config().id();


### PR DESCRIPTION
[21975] Fev 09 13:09:48 [Debug] IMAP :  "15" RECV: * OK [NOMODSEQ] No permanent modsequences 
[21975] Fev 09 13:09:48 [Debug] IMAP :  "15" RECV: a005 OK [READ-WRITE] Select completed. 
[21975] Fev 09 13:09:48 [Warning] ( 21975 ) Failed to execute query; error:"NOT NULL constraint failed: mailfoldercustom.value Unable to fetch row"; statement:"INSERT INTO mailfoldercustom (id,name,value) VALUES (1550,'qmf-highestmodseq','')" 
[21975] Fev 09 13:09:48 [Warning] Failed to execute query; error:"NOT NULL constraint failed: mailfoldercustom.value Unable to fetch row"; statement:"INSERT INTO mailfoldercustom (id,name,value) VALUES (1550,'qmf-highestmodseq','')" 
[21975] Fev 09 13:09:48 [Warning] Could not execute query "mailfoldercustom update custom insert query" 
[21975] Fev 09 13:09:48 [Warning] 21975 Unable to updateFolder - constraint failure 
[21975] Fev 09 13:09:48 [Warning] Unable to update folder HIGHESTMODSEQ for account: 1560 