### PR TITLE
[qmf] Don't explicit delete QDataStream when stream reset is needed.

### DIFF
--- a/qmf/src/libraries/qmfclient/longstream.cpp
+++ b/qmf/src/libraries/qmfclient/longstream.cpp
@@ -87,13 +87,16 @@ LongStream::~LongStream()
 
 void LongStream::reset()
 {
-    delete ts;
-
     tmpFile->resize( 0 );
     tmpFile->close();
     tmpFile->open();
 
-    ts = new QDataStream( tmpFile );
+    if (ts) {
+        ts->setDevice(tmpFile);
+    } else {
+        ts = new QDataStream( tmpFile );
+    }
+
     len = 0;
     appendedBytes = minCheck;
 
@@ -105,8 +108,6 @@ QString LongStream::detach()
 {
     QString detachedName = fileName();
 
-    delete ts;
-
     tmpFile->setAutoRemove(false);
     tmpFile->close();
     delete tmpFile;
@@ -117,7 +118,12 @@ QString LongStream::detach()
     tmpFile->open();
     tmpFile->setPermissions(QFile::ReadOwner | QFile::WriteOwner);
 
-    ts = new QDataStream( tmpFile );
+    if (ts) {
+        ts->setDevice(tmpFile);
+    } else {
+        ts = new QDataStream( tmpFile );
+    }
+
     len = 0;
     appendedBytes = minCheck;
 

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -1,6 +1,6 @@
 Name: qmf-qt5
 Summary:    Qt Messaging Framework (QMF) Qt5
-Version:    4.0.4+git46
+Version:    4.0.4+git47
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1 with exception or GPLv3


### PR DESCRIPTION
*** Error in `/usr/bin/messageserver5': free(): invalid pointer: 0x2a13ce60 ***

Program received signal SIGABRT, Aborted.
__libc_do_syscall () at ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:44
44	../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S: No such file or directory.
(gdb) bt
#0  __libc_do_syscall () at ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:44
#1  0x40792cde in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#2  0x40795b64 in __GI_abort () at abort.c:89
#3  0x407bc0bc in __libc_message (do_abort=<optimized out>, fmt=0x4084e0c0 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/posix/libc_fatal.c:175
#4  0x407c4dc6 in malloc_printerr (ptr=<optimized out>, str=0x4084e1f4 "free(): invalid pointer", action=1) at malloc.c:4996
#5  _int_free (av=<optimized out>, p=<optimized out>, have_lock=0) at malloc.c:3840
#6  0x407c7206 in __GI___libc_free (mem=<optimized out>) at malloc.c:2946
#7  0x403d5e24 in cleanup (pointer=<optimized out>) at ../../src/corelib/tools/qscopedpointer.h:62
#8  ~QScopedPointer (this=0x2a1c8780, __in_chrg=<optimized out>) at ../../src/corelib/tools/qscopedpointer.h:109
#9  QDataStream::~QDataStream (this=0x2a1c8780, __in_chrg=<optimized out>) at io/qdatastream.cpp:360
#10 0x400ba432 in LongStream::reset (this=0x2a1b4b90) at longstream.cpp:90
#11 0x4322b00a in clearResponse (this=0x2a1b4b80) at imapprotocol.cpp:3374
#12 ImapProtocol::nextAction (this=this@entry=0x2a1b4b80, line=...) at imapprotocol.cpp:3513
#13 0x4322b444 in ImapProtocol::processResponse (this=this@entry=0x2a1b4b80, line=...) at imapprotocol.cpp:3495
#14 0x4322b6a0 in ImapProtocol::incomingData (this=0x2a1b4b80) at imapprotocol.cpp:3340
#15 0x43269e7e in ImapProtocol::qt_static_metacall (_o=<optimized out>, _c=<optimized out>, _id=<optimized out>, _a=<optimized out>) at moc_imapprotocol.cpp:209
#16 0x404810e8 in QMetaObject::activate (sender=0x2a1b4c18, signalOffset=<optimized out>, local_signal_index=<optimized out>, argv=0x0) at kernel/qobject.cpp:3580
#17 0x40489726 in QTimer::timerEvent (this=0x2a1b4c18, e=<optimized out>) at kernel/qtimer.cpp:255
#18 0x40481bc6 in QObject::event (this=0x2a1b4c18, e=<optimized out>) at kernel/qobject.cpp:1128
#19 0x4046246c in QCoreApplication::notify (this=<optimized out>, receiver=0x2a1b4c18, event=0xbefff3b0) at kernel/qcoreapplication.cpp:948
#20 0x4046223e in QCoreApplication::notifyInternal (this=0xbefff52c, receiver=<optimized out>, event=<optimized out>) at kernel/qcoreapplication.cpp:886
#21 0x4049c10a in sendEvent (event=0xbefff3b0, receiver=<optimized out>) at ../../src/corelib/kernel/qcoreapplication.h:232
#22 QTimerInfoList::activateTimers (this=0x2a0644b4) at kernel/qtimerinfo_unix.cpp:643
#23 0x4049c4a0 in timerSourceDispatch (source=0x2a064480) at kernel/qeventdispatcher_glib.cpp:188
#24 0x42444b86 in g_main_context_dispatch () from /usr/lib/libglib-2.0.so.0
#25 0x42444e12 in ?? () from /usr/lib/libglib-2.0.so.0
#26 0x42444e8e in g_main_context_iteration () from /usr/lib/libglib-2.0.so.0
#27 0x4049c644 in QEventDispatcherGlib::processEvents (this=0x2a064260, flags=...) at kernel/qeventdispatcher_glib.cpp:438
#28 0x40460f68 in QEventLoop::exec (this=0xbefff4ec, flags=...) at kernel/qeventloop.cpp:212
#29 0x4046609c in QCoreApplication::exec () at kernel/qcoreapplication.cpp:1139
#30 0x2a007c5c in main (argc=1, argv=<optimized out>) at main.cpp:88