### PR TITLE
[qmf] Handle 'Deleted' flag properly for IMAP accounts.

### DIFF
--- a/qmf/src/plugins/messageservices/imap/imapprotocol.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapprotocol.cpp
@@ -3700,6 +3700,9 @@ void ImapProtocol::createMail(const QString &uid, const QDateTime &timeStamp, in
     if (flags & MFlag_Answered) {
         mail.setStatus( QMailMessage::Replied, true );
     }
+    if (flags & MFlag_Deleted) {
+        mail.setStatus( QMailMessage::Removed, true);
+    }
 
     mail.setMessageType( QMailMessage::Email );
     mail.setSize( size );


### PR DESCRIPTION
Some email clients (e.g Thunderbird) have an option to just flag a email
as deleted and still leave it around, those will go way once the folder is
expunged or they can also be marked as undeleted before that. We were
not handling this case well before, now those emails are correctly updated
and the client can choose to show them or just hide them from the lists checking
the status flag QMailMessage::Removed.