### PR TITLE
[imap] Gracefully handle bodystructure where boundaries are reported as NIL

### DIFF
--- a/qmf/src/libraries/qmfclient/qmailmessage.cpp
+++ b/qmf/src/libraries/qmfclient/qmailmessage.cpp
@@ -3948,8 +3948,13 @@ const QMailMessagePart& QMailMessagePartContainerPrivate::partAt(const QMailMess
     const QList<QMailMessagePart>* partList = &_messageParts; 
 
     foreach (uint index, location.d->_indices) {
-        part = &(partList->at(index - 1));
-        partList = &(part->impl<const QMailMessagePartContainerPrivate>()->_messageParts);
+        if (index >= 0 && index <= partList->size()) {
+            part = &(partList->at(index - 1));
+            partList = &(part->impl<const QMailMessagePartContainerPrivate>()->_messageParts);
+        } else {
+            qMailLog(Messaging) << Q_FUNC_INFO << "Invalid index, container does not have a part at " << index;
+            Q_ASSERT(false);
+        }
     }
 
     Q_ASSERT(part);
@@ -3962,8 +3967,13 @@ QMailMessagePart& QMailMessagePartContainerPrivate::partAt(const QMailMessagePar
     QList<QMailMessagePart>* partList = &_messageParts; 
 
     foreach (uint index, location.d->_indices) {
-        part = &((*partList)[index - 1]);
-        partList = &(part->impl<QMailMessagePartContainerPrivate>()->_messageParts);
+        if (index >= 0 && index <= partList->size()) {
+            part = &((*partList)[index - 1]);
+            partList = &(part->impl<QMailMessagePartContainerPrivate>()->_messageParts);
+        } else {
+            qMailLog(Messaging) << Q_FUNC_INFO << "Invalid index, container does not have a part at " << index;
+            Q_ASSERT(false);
+        }
     }
 
     return *part;

--- a/qmf/src/plugins/messageservices/imap/imapstructure.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapstructure.cpp
@@ -435,7 +435,12 @@ void setMultipartFromDescription(const QStringList &structure, QMailMessagePartC
         }
         for ( ; (it != end) && ((it + 1) != end); it += 2) {
             if ((*it).trimmed().toUpper() == "BOUNDARY") {
-                container->setBoundary((*(it + 1)).toLatin1());
+                const QString boundary((*(it + 1)));
+                if (boundary.toUpper() == "NIL") {
+                    container->setBoundary(QByteArray());
+                } else {
+                    container->setBoundary(boundary.toLatin1());
+                }
             }
         }
     }


### PR DESCRIPTION
Some servers (e.g mail.ru) report boundaries as NIL for multipart messages.
from my understanding of RFC2046[1] this is invalid, but we can gracefully handle
those by setting them to empty.
Avoids crash when requesting a partAt() for a message that does not exist,
this happened due to NIL boundaries, but no need to crash in such cases.

example:

SEND UID FETCH 36 (FLAGS UID INTERNALDATE RFC822.SIZE BODYSTRUCTURE RFC822.HEADER)
RECV: * 7 FETCH (FLAGS (\Unseen) UID 36 INTERNALDATE "12-Mar-2015 09:25:30 +0300" RFC822.SIZE 18142 BODYSTRUCTURE (("text" "plain" ("charset" "utf-8") NIL NIL "quoted-printable" 34433 0 NIL NIL NIL NIL)("text" "html" ("charset" "utf-8") NIL NIL "quoted-printable" 108403 0 NIL NIL NIL NIL) "alternative" ("boundary" NIL)) RFC822.HEADER {2558}

[1] - https://tools.ietf.org/html/rfc2046