### PR TITLE
[qmf] Use QTextDocument to parse html.

### DIFF
--- a/qmf/src/libraries/qmfclient/qmailmessage.h
+++ b/qmf/src/libraries/qmfclient/qmailmessage.h
@@ -814,6 +814,9 @@ private:
 
     static QMailMessage fromRfc2822(LongString& ls);
     void refreshPreview();
+#ifdef USE_HTML_PARSER
+    static QString htmlToPlainText(const QString &html);
+#endif
 
 public:
     virtual QString preview() const;

--- a/qmf/src/libraries/qmfclient/qmfclient.pro
+++ b/qmf/src/libraries/qmfclient/qmfclient.pro
@@ -17,6 +17,11 @@ win32: {
 }
 
 QT = core sql network
+
+contains(DEFINES, USE_HTML_PARSER) {
+    QT += gui
+}
+
 DEPENDPATH += .
 INCLUDEPATH += support
 

--- a/qmf/src/tools/messageserver/main.cpp
+++ b/qmf/src/tools/messageserver/main.cpp
@@ -45,13 +45,20 @@
 #include <qmaillog.h>
 #include <qloggers.h>
 #include <signal.h>
+#ifdef USE_HTML_PARSER
+#include <QtGui>
+#endif
 
 #if !defined(NO_SHUTDOWN_SIGNAL_HANDLING) && defined(Q_OS_UNIX)
 
 static void shutdown(int n)
 {
     qMailLog(Messaging) << "Received signal" << n << ", shutting down.";
+#ifdef USE_HTML_PARSER
+    QGuiApplication::exit();
+#else
     QCoreApplication::exit();
+#endif
 }
 #endif
 
@@ -66,7 +73,12 @@ static void recreateLoggers(int n)
 
 Q_DECL_EXPORT int main(int argc, char** argv)
 {
+#ifdef USE_HTML_PARSER
+    // Need for html parsing by <QTextdocument> in qmailmessage.cpp
+    QGuiApplication app(argc, argv);
+#else
     QCoreApplication app(argc, argv);
+#endif
 
     // This is ~/.config/QtProject/Messageserver.conf
     qMailLoggersRecreate("QtProject", "Messageserver", "Msgsrv");

--- a/qmf/src/tools/messageserver/messageserver.pro
+++ b/qmf/src/tools/messageserver/messageserver.pro
@@ -26,6 +26,10 @@ equals(QT_MAJOR_VERSION, 5){
 CONFIG += qmfmessageserver qmfclient
 QT = core
 
+contains(DEFINES, USE_HTML_PARSER) {
+    QT += gui
+}
+
 !contains(DEFINES,QMF_NO_MESSAGE_SERVICE_EDITOR) {
     QT += gui
     equals(QT_MAJOR_VERSION, 5): QT += widgets

--- a/rpm/qmf-qt5.spec
+++ b/rpm/qmf-qt5.spec
@@ -134,6 +134,7 @@ This package contains the documentation for Qt Messaging Framework (QMF).
     DEFINES+=MESSAGESERVER_PLUGINS \
     DEFINES+=QMF_NO_MESSAGE_SERVICE_EDITOR \
     DEFINES+=USE_KEEPALIVE \
+    DEFINES+=USE_HTML_PARSER \
     CONFIG+=syslog
 
 make %{?_smp_mflags}


### PR DESCRIPTION
Regular expression are not appropriated tool to parse a none regular language
like html, a proper parse should be used.
This commit introduces a dependency on QtGui making the messageserver
binary marginally bigger in size.