### PR TITLE
[imap-idle] Check if IDLE connection needs to be established after login. Fixes JB#28693

### DIFF
--- a/qmf/src/plugins/messageservices/imap/imapclient.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapclient.cpp
@@ -987,6 +987,16 @@ void ImapClient::commandTransition(ImapCommand command, OperationStatus status)
                 }
 #endif
             }
+            // After logging in server capabilities reported may change so we need to
+            // check if IDLE is already established, when enabled
+            if (!_waitingForIdle && !_idlesEstablished
+                && _protocol.supportsCapability("IDLE")
+                && !_waitingForIdleFolderIds.isEmpty()
+                && _pushConnectionsReserved) {
+                _waitingForIdle = true;
+                monitor(_waitingForIdleFolderIds);
+                emit updateStatus( tr("Logging in idle connection" ) );
+            }
 
             bool compressCapable(_protocol.capabilities().contains("COMPRESS=DEFLATE", Qt::CaseInsensitive));
             if (!_protocol.encrypted() && QMFALLOWCOMPRESS && compressCapable && !_protocol.compress()) {

--- a/qmf/src/plugins/messageservices/imap/imapservice.cpp
+++ b/qmf/src/plugins/messageservices/imap/imapservice.cpp
@@ -1936,7 +1936,7 @@ void ImapService::onOnlineStateChanged(bool isOnline)
     qMailLog(Messaging) << "IDLE Session: Network state changed: " << isOnline;
     if (accountPushEnabled() && isOnline && (!_networkSession || _networkSession->state() != QNetworkSession::Connected)) {
         openIdleSession();
-    } else  if (!isOnline) {
+    } else if (!isOnline) {
         onSessionError(QNetworkSession::InvalidConfigurationError);
         closeIdleSession();
     }


### PR DESCRIPTION
Some servers only advertise full capabilities after successful login,
so we need to check if IDLE connection needs to be established in such
cases.